### PR TITLE
Jscript source fix

### DIFF
--- a/vulnerabilities/javascript/source/high.php
+++ b/vulnerabilities/javascript/source/high.php
@@ -1,5 +1,5 @@
 <?php
 $page[ 'body' ] .= <<<EOF
-<script src="/vulnerabilities/javascript/source/high.js"></script>
+<script src="/dvwa/vulnerabilities/javascript/source/high.js"></script>
 EOF;
 ?>

--- a/vulnerabilities/javascript/source/medium.php
+++ b/vulnerabilities/javascript/source/medium.php
@@ -1,5 +1,5 @@
 <?php
 $page[ 'body' ] .= <<<EOF
-<script src="/vulnerabilities/javascript/source/medium.js"></script>
+<script src="/dvwa/vulnerabilities/javascript/source/medium.js"></script>
 EOF;
 ?>


### PR DESCRIPTION
The pages medium.php and high.php for the Javascript aren't able to load the medium.js and high.js script files. Slight tweaks to the 'script src=' path fixed that.