### PR TITLE
add hastebin alternative to pastebin

### DIFF
--- a/vulnerabilities/csp/help/help.php
+++ b/vulnerabilities/csp/help/help.php
@@ -18,7 +18,7 @@
 
 		<h3>Low Level</h3>
 		<p>Examine the policy to find all the sources that can be used to host external script files.</p>
-		<pre>Spoiler: <span class="spoiler">Scripts can be included from Pastebin, try storing some JavaScript on there and then loading it in.</span></pre>
+		<pre>Spoiler: <span class="spoiler">Scripts can be included from Pastebin or Hastebin, try storing some JavaScript on there and then loading it in.</span></pre>
 
 		<br />
 

--- a/vulnerabilities/csp/source/low.php
+++ b/vulnerabilities/csp/source/low.php
@@ -1,9 +1,10 @@
 <?php
 
-$headerCSP = "Content-Security-Policy: script-src 'self' https://pastebin.com http://hastebin.com example.com code.jquery.com https://ssl.google-analytics.com ;"; // allows js from self, pastebin.com, hastebin.com, jquery and google analytics.
+$headerCSP = "Content-Security-Policy: script-src 'self' https://pastebin.com hastebin.com example.com code.jquery.com https://ssl.google-analytics.com ;"; // allows js from self, pastebin.com, hastebin.com, jquery and google analytics.
 
 header($headerCSP);
 
+# These might work if you can't create your own for some reason
 # https://pastebin.com/raw/R570EE00
 # https://hastebin.com/raw/ohulaquzex
 
@@ -16,7 +17,6 @@ $page[ 'body' ] .= "
 }
 $page[ 'body' ] .= '
 <form name="csp" method="POST">
-	<p><strong>Currently broken due to changes at Pastebin, looking for alternatives.</strong></p>
 	<p>You can include scripts from external sources, examine the Content Security Policy and enter a URL to include here:</p>
 	<input size="50" type="text" name="include" value="" id="include" />
 	<input type="submit" value="Include" />

--- a/vulnerabilities/csp/source/low.php
+++ b/vulnerabilities/csp/source/low.php
@@ -1,10 +1,11 @@
 <?php
 
-$headerCSP = "Content-Security-Policy: script-src 'self' https://pastebin.com  example.com code.jquery.com https://ssl.google-analytics.com ;"; // allows js from self, pastebin.com, jquery and google analytics.
+$headerCSP = "Content-Security-Policy: script-src 'self' https://pastebin.com http://hastebin.com example.com code.jquery.com https://ssl.google-analytics.com ;"; // allows js from self, pastebin.com, hastebin.com, jquery and google analytics.
 
 header($headerCSP);
 
 # https://pastebin.com/raw/R570EE00
+# https://hastebin.com/raw/ohulaquzex
 
 ?>
 <?php


### PR DESCRIPTION
Tested to solve #382 
hastebin's headers doesn't include `x-content-type-options: nosniff`
```
$ curl -i https://hastebin.com/raw/ohulaquzex

HTTP/2 200 
date: Fri, 11 Sep 2020 09:27:22 GMT
content-type: text/plain; charset=UTF-8
set-cookie: redacted
x-ratelimit-limit: 500
x-ratelimit-remaining: 499
via: 1.1 vegur
cf-cache-status: DYNAMIC
cf-request-id: 051e16b6c7000019042406a200000001
expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
server: cloudflare
cf-ray: 5d105a37acce1904-SIN

alert("hastebin");
```
![poc](https://user-images.githubusercontent.com/54675998/92901936-162d1800-f44b-11ea-8beb-69d74f750dd5.gif)