### PR TITLE
Several improvements for broken URL detection test.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [master]
   schedule:
-    - cron: "0 0 * * *"
+    # Every Sunday at 0AM UTC
+    - cron: "0 0 * * 0"
 
 jobs:
   build:

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -1,6 +1,7 @@
 import glob
 import re
 import requests
+import time
 
 
 def get_php_files():
@@ -18,7 +19,7 @@ def get_urls(filename):
         return matches
 
 
-def check(url):
+def check_once(url):
     try:
         headers = {
             'User-Agent':
@@ -26,16 +27,28 @@ def check(url):
         }
         response = requests.get(url, verify=False, headers=headers)
     except requests.exceptions.ConnectionError:
-        return 0
-    return response.status_code
+        return False, -1
+    return response.ok, response.status_code
+
+
+def check(url):
+    # We try for 5 times, with 3 seconds interval.
+    try_count = 5
+    try_interval = 3
+    for i in range(try_count):
+        ok, status_code = check_once(url)
+        if ok:
+            break
+        time.sleep(try_interval)
+    return ok, status_code
 
 
 def test_url():
     broken_urls = []
     for php_file in get_php_files():
         for url in get_urls(php_file):
-            status_code = check(url)
-            if status_code not in [200, 300]:
+            ok, status_code = check_once(url)
+            if not ok:
                 broken_urls.append((php_file, url, status_code))
     for php_file, url, status_code in broken_urls:
         print("%s\t%s\t%s" % (php_file, url, status_code))

--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -25,7 +25,7 @@ def check_once(url):
             'User-Agent':
             'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36'
         }
-        response = requests.get(url, verify=False, headers=headers)
+        response = requests.get(url, headers=headers)
     except requests.exceptions.ConnectionError:
         return False, -1
     return response.ok, response.status_code

--- a/vulnerabilities/csrf/help/help.php
+++ b/vulnerabilities/csrf/help/help.php
@@ -53,5 +53,5 @@
 
 	<br />
 
-	<p>Reference: <?php echo dvwaExternalLinkUrlGet( 'https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)' ); ?></p>
+	<p>Reference: <?php echo dvwaExternalLinkUrlGet( 'https://owasp.org/www-community/attacks/csrf' ); ?></p>
 </div>

--- a/vulnerabilities/csrf/index.php
+++ b/vulnerabilities/csrf/index.php
@@ -77,7 +77,7 @@ $page[ 'body' ] .= "
 
 	<h2>More Information</h2>
 	<ul>
-		<li>" . dvwaExternalLinkUrlGet( 'https://www.owasp.org/index.php/Cross-Site_Request_Forgery' ) . "</li>
+		<li>" . dvwaExternalLinkUrlGet( 'https://owasp.org/www-community/attacks/csrf' ) . "</li>
 		<li>" . dvwaExternalLinkUrlGet( 'http://www.cgisecurity.com/csrf-faq.html' ) . "</li>
 		<li>" . dvwaExternalLinkUrlGet( 'https://en.wikipedia.org/wiki/Cross-site_request_forgery ' ) . "</li>
 	</ul>

--- a/vulnerabilities/xss_d/index.php
+++ b/vulnerabilities/xss_d/index.php
@@ -68,8 +68,8 @@ EOF;
 $page[ 'body' ] .= "
 	<h2>More Information</h2>
 	<ul>
-		<li>" . dvwaExternalLinkUrlGet( 'https://www.owasp.org/index.php/Cross-site_Scripting_(XSS)' ) . "</li>
-		<li>" . dvwaExternalLinkUrlGet( 'https://www.owasp.org/index.php/Testing_for_DOM-based_Cross_site_scripting_(OTG-CLIENT-001)' ) . "</li>
+		<li>" . dvwaExternalLinkUrlGet( 'https://owasp.org/www-community/attacks/xss/' ) . "</li>
+		<li>" . dvwaExternalLinkUrlGet( 'https://owasp.org/www-community/attacks/DOM_Based_XSS' ) . "</li>
 		<li>" . dvwaExternalLinkUrlGet( 'https://www.acunetix.com/blog/articles/dom-xss-explained/' ) . "</li>
 	</ul>
 </div>\n";


### PR DESCRIPTION
1. run once a week
2. try for 5 times, with 3 seconds interval.
3. use the default .ok, rather than explicit status code check.