### PR TITLE
home: update link to Mutillidae

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ Dockerfile
 
 # Vim swap files
 .*swp
+
+# VS Code editor files
+*.code-workspace

--- a/index.php
+++ b/index.php
@@ -36,7 +36,7 @@ $page[ 'body' ] .= "
 	<h2>More Training Resources</h2>
 	<p>DVWA aims to cover the most commonly seen vulnerabilities found in today's web applications. However there are plenty of other issues with web applications. Should you wish to explore any additional attack vectors, or want more difficult challenges, you may wish to look into the following other projects:</p>
 	<ul>
-		<li>" . dvwaExternalLinkUrlGet( 'http://sourceforge.net/projects/mutillidae/files/mutillidae-project/', 'NOWASP') . " (formerly known as " . dvwaExternalLinkUrlGet( 'http://www.irongeek.com/i.php?page=mutillidae/mutillidae-deliberately-vulnerable-php-owasp-top-10', 'Mutillidae' ) . ")</li>
+		<li>" . dvwaExternalLinkUrlGet( 'https://github.com/webpwnized/mutillidae', 'Mutillidae') . ")</li>
 		<li>" . dvwaExternalLinkUrlGet( 'https://www.owasp.org/index.php/OWASP_Broken_Web_Applications_Project', 'OWASP Broken Web Applications Project
 ') . "</li>
 	</ul>


### PR DESCRIPTION
The old link pointed to a sourceforge project that tells it has been migrated to GitHub. 
So we can safely point the link directly to the GH repo.