### PR TITLE
Add support for multi-lingual help pages.

### DIFF
--- a/config/config.inc.php.dist
+++ b/config/config.inc.php.dist
@@ -42,4 +42,9 @@ $_DVWA[ 'default_phpids_level' ] = 'disabled';
 #   The default is 'disabled'. You can set this to be either 'true' or 'false'.
 $_DVWA[ 'default_phpids_verbose' ] = 'false';
 
+# Default locale
+#   Default locale for the help page shown with each session.
+#   The default is 'en'. You may wish to set this to either 'en' or 'zh'.
+$_DVWA[ 'default_locale' ] = 'en';
+
 ?>

--- a/dvwa/includes/dvwaPage.inc.php
+++ b/dvwa/includes/dvwaPage.inc.php
@@ -37,6 +37,8 @@ if( !isset( $_COOKIE[ 'security' ] ) || !in_array( $_COOKIE[ 'security' ], $secu
 		dvwaPhpIdsEnabledSet( false );
 }
 
+dvwaLocaleSet( $_DVWA[ 'default_locale' ] );
+
 // DVWA version
 function dvwaVersionGet() {
 	return '1.10 *Development*';
@@ -149,6 +151,22 @@ function dvwaSecurityLevelSet( $pSecurityLevel ) {
 }
 
 
+function dvwaLocaleGet() {	
+	$dvwaSession =& dvwaSessionGrab();
+	return $dvwaSession[ 'locale' ];
+}
+
+
+function dvwaLocaleSet( $pLocale ) {
+	$dvwaSession =& dvwaSessionGrab();
+	$locales = array('en', 'zh');
+	if( in_array( $pLocale, $locales) ) {
+		$dvwaSession[ 'locale' ] = $pLocale;
+	} else {
+		$dvwaSession[ 'locale' ] = 'en';
+	}
+}
+
 // Start message functions --
 
 function dvwaMessagePush( $pMessage ) {
@@ -256,6 +274,9 @@ function dvwaHtmlEcho( $pPage ) {
 
 	$phpIdsHtml   = '<em>PHPIDS:</em> ' . ( dvwaPhpIdsIsEnabled() ? 'enabled' : 'disabled' );
 	$userInfoHtml = '<em>Username:</em> ' . ( dvwaCurrentUser() );
+	$securityLevelHtml = "<em>Security Level:</em> {$securityLevelHtml}";
+	$localeHtml = '<em>Locale:</em> ' . ( dvwaLocaleGet() );
+	
 
 	$messagesHtml = messagesPopAllToHtml();
 	if( $messagesHtml ) {
@@ -263,8 +284,8 @@ function dvwaHtmlEcho( $pPage ) {
 	}
 
 	$systemInfoHtml = "";
-	if( dvwaIsLoggedIn() )
-		$systemInfoHtml = "<div align=\"left\">{$userInfoHtml}<br /><em>Security Level:</em> {$securityLevelHtml}<br />{$phpIdsHtml}</div>";
+	if( dvwaIsLoggedIn() ) 
+		$systemInfoHtml = "<div align=\"left\">{$userInfoHtml}<br />{$securityLevelHtml}<br />{$localeHtml}<br />{$phpIdsHtml}</div>";
 	if( $pPage[ 'source_button' ] ) {
 		$systemInfoHtml = dvwaButtonSourceHtmlGet( $pPage[ 'source_button' ] ) . " $systemInfoHtml";
 	}
@@ -425,7 +446,8 @@ function dvwaExternalLinkUrlGet( $pLink,$text=null ) {
 
 function dvwaButtonHelpHtmlGet( $pId ) {
 	$security = dvwaSecurityLevelGet();
-	return "<input type=\"button\" value=\"View Help\" class=\"popup_button\" id='help_button' data-help-url='" . DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/view_help.php?id={$pId}&security={$security}' )\">";
+	$locale = dvwaLocaleGet();
+	return "<input type=\"button\" value=\"View Help\" class=\"popup_button\" id='help_button' data-help-url='" . DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/view_help.php?id={$pId}&security={$security}&locale={$locale}' )\">";
 }
 
 

--- a/vulnerabilities/view_help.php
+++ b/vulnerabilities/view_help.php
@@ -10,9 +10,14 @@ $page[ 'title' ] = 'Help' . $page[ 'title_separator' ].$page[ 'title' ];
 
 $id       = $_GET[ 'id' ];
 $security = $_GET[ 'security' ];
+$locale = $_GET[ 'locale' ];
 
 ob_start();
-eval( '?>' . file_get_contents( DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/{$id}/help/help.php" ) . '<?php ' );
+if ($locale == 'en') {
+	eval( '?>' . file_get_contents( DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/{$id}/help/help.php" ) . '<?php ' );
+} else {
+	eval( '?>' . file_get_contents( DVWA_WEB_PAGE_TO_ROOT . "vulnerabilities/{$id}/help/help.{$locale}.php" ) . '<?php ' );
+}
 $help = ob_get_contents();
 ob_end_clean();
 


### PR DESCRIPTION
Implemented as proposed in #432.

Different help pages can be loaded by setting $_DVWA['default_locale'].

You can test it by 
1. setting `$_DVWA['default_locale'] = 'zh'` in `config/config.inc.php`
2. add a page as `vulnerabilities/brute/help/help.zh.php`
3. then click the `View help` button of page `http://localhost:8080/DVWA/vulnerabilities/brute/`.

Currently the valid locales are only `['en', 'zh']`. We can add more in the future.