### PR TITLE
Improve elaboration of PHP configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,10 +165,7 @@ Depending on your Operating System, as well as version of PHP, you may wish to a
 * To allow  Remote File Inclusions (RFI):
     * `allow_url_include = on` [[allow_url_include](https://secure.php.net/manual/en/filesystem.configuration.php#ini.allow-url-include)]
     * `allow_url_fopen = on` [[allow_url_fopen](https://secure.php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen)]
-* To allow for SQL Injection (SQLi), if PHP <= v5.4:
-    * `safe_mode = off`  [[safe_mode](https://secure.php.net/manual/en/features.safe-mode.php)]
-    * `magic_quotes_gpc = off` [[magic_quotes_gpc](https://web.archive.org/web/20210111094526/https://www.php.net/manual/en/security.magicquotes.php)]
-* To optinally reduce verbosity by hiding PHP warning messages:
+* To optionally reduce verbosity by hiding PHP warning messages:
     * `display_errors = off` [[display_errors](https://secure.php.net/manual/en/errorfunc.configuration.php#ini.display-errors)]
 
 **File: `config/config.inc.php`**:

--- a/README.md
+++ b/README.md
@@ -162,12 +162,14 @@ Depending on your Operating System, as well as version of PHP, you may wish to a
 * `./external/phpids/0.6/lib/IDS/tmp/phpids_log.txt` - Needs to be writable by the web service (if you wish to use PHPIDS).
 
 **PHP configuration**:
-
-* `allow_url_include = on` - Allows for Remote File Inclusions (RFI)   [[allow_url_include](https://secure.php.net/manual/en/filesystem.configuration.php#ini.allow-url-include)]
-* `allow_url_fopen = on` -  Allows for Remote File Inclusions (RFI)    [[allow_url_fopen](https://secure.php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen)]
-* `safe_mode = off` - (If PHP <= v5.4) Allows for SQL Injection (SQLi) [[safe_mode](https://secure.php.net/manual/en/features.safe-mode.php)]
-* `magic_quotes_gpc = off` - (If PHP <= v5.4) Allows for SQL Injection (SQLi) [[magic_quotes_gpc](https://secure.php.net/manual/en/security.magicquotes.php)]
-* `display_errors = off` - (Optional) Hides PHP warning messages to make it less verbose [[display_errors](https://secure.php.net/manual/en/errorfunc.configuration.php#ini.display-errors)]
+* To allow  Remote File Inclusions (RFI):
+    * `allow_url_include = on` [[allow_url_include](https://secure.php.net/manual/en/filesystem.configuration.php#ini.allow-url-include)]
+    * `allow_url_fopen = on` [[allow_url_fopen](https://secure.php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen)]
+* To allow for SQL Injection (SQLi), if PHP <= v5.4:
+    * `safe_mode = off`  [[safe_mode](https://secure.php.net/manual/en/features.safe-mode.php)]
+    * `magic_quotes_gpc = off` [[magic_quotes_gpc](https://web.archive.org/web/20210111094526/https://www.php.net/manual/en/security.magicquotes.php)]
+* To optinally reduce verbosity by hiding PHP warning messages:
+    * `display_errors = off` [[display_errors](https://secure.php.net/manual/en/errorfunc.configuration.php#ini.display-errors)]
 
 **File: `config/config.inc.php`**:
 


### PR DESCRIPTION
Revise hierarchy of PHP configuration to describe item list for each purpose rather than duplicating the purpose for each affected configuration item. Fix dead link to latest archived copy of the now deprecated magic_quotes_gpc documention page.