### PR TITLE
Resolves issue #529

### DIFF
--- a/dvwa/includes/dvwaPage.inc.php
+++ b/dvwa/includes/dvwaPage.inc.php
@@ -49,14 +49,14 @@ else {
 $maxlifetime = 86400;
 $secure = false;
 
-session_set_cookie_params([
+session_set_cookie_params(array(
 	'lifetime' => $maxlifetime,
 	'path' => '/',
 	'domain' => $_SERVER['HTTP_HOST'],
 	'secure' => $secure,
 	'httponly' => $httponly,
 	'samesite' => $samesite
-]);
+));
 session_start();
 
 if (!array_key_exists ("default_locale", $_DVWA)) {


### PR DESCRIPTION
Using square brackets for arrays in the file /dvwa/dvwa/includes/dvwaPage.inc.php on line 52 causes a parse error when using PHP versions less than 5.4.
