### PR TITLE
Automated Docker image build and push to github registry

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,36 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name : Build and push DVWA image
+      run: |
+        IMAGE_ID=ghcr.io/${{ github.repository_owner }}/dvwa
+        IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+        [ "$VERSION" == "master" ] && VERSION=latest
+        echo IMAGE_ID=$IMAGE_ID
+        echo VERSION=$VERSION
+        docker build . --tag dvwa
+        docker tag dvwa $IMAGE_ID:$VERSION
+        docker push $IMAGE_ID:$VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,7 @@ RUN apt-get update \
 
 COPY --chown=www-data:www-data . .
 COPY --chown=www-data:www-data config/config.inc.php.dist config/config.inc.php
+
+LABEL org.opencontainers.image.source=https://github.com/digininja/DVWA
+LABEL org.opencontainers.image.description="DVWA pre-built container."
+LABEL org.opencontainers.image.licenses="gpl-3.0"


### PR DESCRIPTION
Updated the Dockerfile to include recommended labels for hosting images, and workflow action for generating the image. It should show up under the project's packages if you accept the pull request.  Note, that  you may need to turn on package creation in the settings before it will work.