### PR TITLE
Docker: Pull image from `ghcr` instead of building locally as default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 FROM docker.io/library/php:8-apache
+
+LABEL org.opencontainers.image.source=https://github.com/digininja/DVWA
+LABEL org.opencontainers.image.description="DVWA pre-built image."
+LABEL org.opencontainers.image.licenses="gpl-3.0"
+
 WORKDIR /var/www/html
 
 # https://www.php.net/manual/en/image.installation.php
@@ -11,7 +16,3 @@ RUN apt-get update \
 
 COPY --chown=www-data:www-data . .
 COPY --chown=www-data:www-data config/config.inc.php.dist config/config.inc.php
-
-LABEL org.opencontainers.image.source=https://github.com/digininja/DVWA
-LABEL org.opencontainers.image.description="DVWA pre-built container."
-LABEL org.opencontainers.image.licenses="gpl-3.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /var/www/html
 RUN apt-get update \
  && export DEBIAN_FRONTEND=noninteractive \
  && apt-get install -y zlib1g-dev libpng-dev libjpeg-dev libfreetype6-dev iputils-ping \
- && rm -rf /var/lib/apt/lists/* \
+ && apt-get clean -y && rm -rf /var/lib/apt/lists/* \
  && docker-php-ext-configure gd --with-jpeg --with-freetype \
  # Use pdo_sqlite instead of pdo_mysql if you want to use sqlite
  && docker-php-ext-install gd mysqli pdo pdo_mysql

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /var/www/html
 
 # https://www.php.net/manual/en/image.installation.php
 RUN apt-get update \
+ && export DEBIAN_FRONTEND=noninteractive \
  && apt-get install -y zlib1g-dev libpng-dev libjpeg-dev libfreetype6-dev iputils-ping \
  && rm -rf /var/lib/apt/lists/* \
  && docker-php-ext-configure gd --with-jpeg --with-freetype \

--- a/README.md
+++ b/README.md
@@ -80,23 +80,11 @@ This [video](https://youtu.be/Yzksa_WjnY0) walks you through the installation pr
 
 ### Docker
 
-It is possible to run DVWA with containers.
+Thanks to [hoang-himself](https://github.com/hoang-himself) and [JGillam](https://github.com/JGillam), every commit to the `master` branch causes a Docker image to be built and ready to be pulled down from GitHub Container Registry.
 
-#### Automated Build
+For more information on what you are getting, you can browse [the prebuilt Docker images](https://github.com/digininja/DVWA/pkgs/container/dvwa).
 
-Thanks to [JGillam](https://github.com/JGillam), every commit now causes a docker image to be build ready to be pulled down from GitHub.
-
-You can pull the latest version by doing this:
-
-```
-docker pull ghcr.io/digininja/dvwa:latest
-```
-
-And for more information on what you are getting, see [here](https://github.com/digininja/DVWA/pkgs/container/dvwa).
-
-#### Manual Build
-
-If you would rather build the package manually, [hoang-himself](https://github.com/hoang-himself) did all the hard work setting all the docker stuff up to hopefully make it as easy as possible for you.
+#### Getting Started
 
 Prerequisites: Docker and Docker Compose.
 
@@ -111,7 +99,7 @@ Your Docker data (containers, images, volumes, etc.) should not be affected, but
 
 Then, to get started:
 
-1. Run `docker version` and `docker compose version` to see if you have Docker and Docker Compose properly installed. You should be able to see the version of Docker in the output.
+1. Run `docker version` and `docker compose version` to see if you have Docker and Docker Compose properly installed. You should be able to see their versions in the output.
 
     For example:
 
@@ -135,13 +123,22 @@ Then, to get started:
     If you don't see anything or get a command not found error, follow the prerequisites to setup Docker and Docker Compose.
 
 2. Clone or download this repository and extract (see [Download](#download)).
-3. Open a terminal of your choice and change its working directory to `DVWA`.
-4. `docker compose up -d`.
+3. Open a terminal of your choice and change its working directory into this folder (`DVWA`).
+4. Run `docker compose up -d`.
 
 DVWA is now available at `http://localhost:4280`.
 
 **Notice that for running DVWA in containers, the web server is listening on port 4280 instead of the usual port of 80.**
 For more information on this decision, see [I want to run DVWA on a different port](#i-want-to-run-dvwa-on-a-different-port).
+
+#### Local Build
+
+If you made local changes and want to build the project from local, go to `compose.yml` and change `pull_policy: always` to `pull_policy: build`.
+
+Running `docker compose up -d` should trigger Docker to build an image from local regardless of what is available in the registry.
+
+See also: [`pull_policy`](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#pull_policy
+).
 
 ### Linux Packages
 

--- a/compose.yml
+++ b/compose.yml
@@ -9,6 +9,9 @@ networks:
 services:
   dvwa:
     build: .
+    image: ghcr.io/digininja/dvwa:latest
+    # Change `always` to `build` to build from local source
+    pull_policy: always
     environment:
       - DB_SERVER=db
     depends_on:


### PR DESCRIPTION
This PR also contains non-breaking changes to `Dockerfile`.