### PR TITLE
Tweak some CI workflows

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,6 +27,6 @@ jobs:
         [ "$VERSION" == "master" ] && VERSION=latest
         echo IMAGE_ID=$IMAGE_ID
         echo VERSION=$VERSION
-        docker build . --tag dvwa
-        docker tag dvwa $IMAGE_ID:$VERSION
-        docker push $IMAGE_ID:$VERSION
+        docker image build --tag dvwa .
+        docker image tag dvwa $IMAGE_ID:$VERSION
+        docker image push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,8 +25,12 @@ jobs:
         VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
         [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
         [ "$VERSION" == "master" ] && VERSION=latest
+        COMMIT=$(echo "${{ github.sha }}" | cut -c 1-7)
         echo IMAGE_ID=$IMAGE_ID
         echo VERSION=$VERSION
+        echo COMMIT=$COMMIT
         docker image build --tag dvwa .
         docker image tag dvwa $IMAGE_ID:$VERSION
+        docker image tag dvwa $IMAGE_ID:$COMMIT
         docker image push $IMAGE_ID:$VERSION
+        docker image push $IMAGE_ID:$COMMIT

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,20 +1,16 @@
 name: Docker Image CI
 
 on:
+  workflow_dispatch:
   push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+    branches: [master]
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v3
-    
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1
       with:

--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -4,7 +4,11 @@
 name: SL Scan
 
 # This section configures the trigger for the workflow. Feel free to customize depending on your convention
-on: push
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   Scan-Build:


### PR DESCRIPTION
- SL requires write permission to the repo which is disabled by default in forks, making the workflow unintentionally fail
- Docker images is now a source of truth, thus the trigger for CI should be push to `master`
- Docker CI now also tags images with 7 initial characters of the commit hash and pushes them