### PR TITLE
buggy authbypass

### DIFF
--- a/vulnerabilities/authbypass/change_user_details.php
+++ b/vulnerabilities/authbypass/change_user_details.php
@@ -10,6 +10,7 @@ On impossible only the admin is allowed to retrieve the data.
 
 if (dvwaSecurityLevelGet() == "impossible" && dvwaCurrentUser() != "admin") {
 	print json_encode (array ("result" => "fail", "error" => "Access denied"));
+	exit;
 }
 
 if ($_SERVER['REQUEST_METHOD'] != "POST") {


### PR DESCRIPTION
Added `exit;` statement to stop leaking vulnerability to Impossible level.

"""
There are bugs in the get_user_data.php and change_user_details.php files that makes the High and Impossible levels of Authorization Bypass unintentionally vulnerable, sharing the same leaks as Medium. This is not intended, following the Help message. 

Rectified the files by adding `exit;` statements where necessary. 
"""