### PR TITLE
buggy authbypass

### DIFF
--- a/vulnerabilities/authbypass/get_user_data.php
+++ b/vulnerabilities/authbypass/get_user_data.php
@@ -9,6 +9,7 @@ On high and impossible, only the admin is allowed to retrieve the data.
 */
 if ((dvwaSecurityLevelGet() == "high" || dvwaSecurityLevelGet() == "impossible") && dvwaCurrentUser() != "admin") {
 	print json_encode (array ("result" => "fail", "error" => "Access denied"));
+	exit;
 }
 
 $query  = "SELECT user_id, first_name, last_name FROM users";


### PR DESCRIPTION
Added `exit;` statement to stop leaking feature/vulnerability to High and Impossible Levels

"""
There are bugs in the get_user_data.php and change_user_details.php files that makes the High and Impossible levels of Authorization Bypass unintentionally vulnerable, sharing the same leaks as Medium. This is not intended, following the Help message. 

Rectified the files by adding `exit;` statements where necessary. 
"""