### PR TITLE
Fix check to see if disable_authentication is set

### DIFF
--- a/dvwa/includes/dvwaPage.inc.php
+++ b/dvwa/includes/dvwaPage.inc.php
@@ -124,7 +124,7 @@ function dvwaLogin( $pUsername ) {
 function dvwaIsLoggedIn() {
 	global $_DVWA;
 
-	if (in_array("disable_authentication", $_DVWA) && $_DVWA['disable_authentication']) {
+	if (isset($_DVWA['disable_authentication']) && $_DVWA['disable_authentication'] === true) {
 		return true;
 	}
 	$dvwaSession =& dvwaSessionGrab();


### PR DESCRIPTION
Even when setting `$_DVWA[ 'disable_authentication' ] = true;` as specified in the README, the login page was still showing up. This fixes that, allowing tools to bypass the login page.