### PR TITLE
Add nginx configuration files and a Docker Compose setup to make running DVWA more reasonable and easier inside servers

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -7,19 +7,33 @@ networks:
 
 
 services:
+  nginx:
+      build:
+        context: ./nginx
+        dockerfile: Dockerfile
+      container_name: dvwa_nginx
+      volumes:
+        - ./nginx/config/:/etc/nginx/conf.d/
+      networks: 
+        - dvwa
+      ports:
+        - "80:80"
+      depends_on:
+      - dvwa
   dvwa:
     build: .
     image: ghcr.io/digininja/dvwa:latest
     # Change `always` to `build` to build from local source
-    pull_policy: always
+    pull_policy: build
     environment:
       - DB_SERVER=db
+      - SERVER_NAME=localhost.local
     depends_on:
       - db
     networks:
       - dvwa
     ports:
-      - 4280:80
+      - "4280"
     restart: unless-stopped
 
   db:

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx:latest
+
+RUN apt update && apt upgrade -y
+RUN rm /etc/nginx/nginx.conf
+RUN rm /etc/nginx/conf.d/default.conf
+COPY ./nginx.conf /etc/nginx/
+COPY ./config/main.conf /etc/nginx/conf.d

--- a/nginx/config/main.conf
+++ b/nginx/config/main.conf
@@ -1,0 +1,24 @@
+upstream app {
+    server dvwa:4280;
+}
+
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        proxy_pass http://dvwa;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_redirect off;
+    }
+
+    location /static {
+        autoindex on;
+        alias /static/;
+    }
+
+    access_log /var/log/nginx/access.log  main;
+    error_log /var/log/nginx/error.log;
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,32 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+    server_tokens off;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
Add nginx configuration files and a Docker Compose setup to make running DVWA more reasonable and easier inside servers, requiring only 'docker-compose up'. This addition comes from my own project witch_craft pwnbox, which uses DVWA  with Alpine Linux. Maybe it doesn't fully align with the project's goals, but it doesn't cost anything.