### PR TITLE
fix: use safer default for docker port mapping

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -300,14 +300,14 @@ Sebagai contoh, Anda dapat mengubah
 
 ```
 ports:
-  - 4280:80
+  - 127.0.0.1:4280:80
 ```
 
 Menjadi
 
 ```
 ports:
-  - 8806:80
+  - 127.0.0.1:8806:80
 ```
 
 DVWA sekarang dapat diakses di `http://localhost:8806`.

--- a/README.md
+++ b/README.md
@@ -335,17 +335,23 @@ For example, you can change
 
 ```yml
 ports:
-  - 4280:80
+  - 127.0.0.1:4280:80
 ```
 
 to
 
 ```yml
 ports:
-  - 8806:80
+  - 127.0.0.1:8806:80
 ```
 
 DVWA is now accessible at `http://localhost:8806`.
+
+In cases in which you want DVWA to not only be accessible exclusively from your own device, but
+on your local network too (e.g. because you are setting up a test machine for a workshop), you
+can remove the `127.0.0.1:` from the port mapping (or replace it with you LAN IP). This way it
+will listen on all available device. The safe default should always be to only listen on your
+local loopback device. After all, it is a damn vulnerable web application, running on your machine.
 
 #### DVWA auto starts when Docker runs
 

--- a/compose.yml
+++ b/compose.yml
@@ -19,7 +19,7 @@ services:
     networks:
       - dvwa
     ports:
-      - 4280:80
+      - 127.0.0.1:4280:80
     restart: unless-stopped
 
   db:


### PR DESCRIPTION
If the docker port mapping does not use a specific IP, it the port will be opened for all available network devices. This might be potentially dangerous, because people who just quickly want to try out the DVWA are not always aware of this issue. Nevertheless anyone on their local network could then access the DVWA inside the container.

Therefore this commit changes the default to be mapped to the same port only on the local loopback device as the safer default, and adds a short explanation in the respectice section in README, so that people can make it available on all network devices, if they really need to.