### PR TITLE
bug: cookie is not set if the host address is localhost:4320

### DIFF
--- a/vulnerabilities/weak_id/source/high.php
+++ b/vulnerabilities/weak_id/source/high.php
@@ -8,7 +8,7 @@ if ($_SERVER['REQUEST_METHOD'] == "POST") {
 	}
 	$_SESSION['last_session_id_high']++;
 	$cookie_value = md5($_SESSION['last_session_id_high']);
-	setcookie("dvwaSession", $cookie_value, time()+3600, "/vulnerabilities/weak_id/", $_SERVER['HTTP_HOST'], false, false);
+	setcookie("dvwaSession", $cookie_value, time()+3600, "/vulnerabilities/weak_id/", $_SERVER['SERVER_NAME'], false, false);
 }
 
 ?>

--- a/vulnerabilities/weak_id/source/impossible.php
+++ b/vulnerabilities/weak_id/source/impossible.php
@@ -4,6 +4,6 @@ $html = "";
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
 	$cookie_value = sha1(mt_rand() . time() . "Impossible");
-	setcookie("dvwaSession", $cookie_value, time()+3600, "/vulnerabilities/weak_id/", $_SERVER['HTTP_HOST'], true, true);
+	setcookie("dvwaSession", $cookie_value, time()+3600, "/vulnerabilities/weak_id/", $_SERVER['SERVER_NAME'], true, true);
 }
 ?>


### PR DESCRIPTION
I'm using DVWA via docker and noticed a bug that setting cookies doesn't work at the high and impossible level. The problem is that the $domain parameter is set to localhost:4320 - this causes the setcookie function to fail. I changed to the SERVER_NAME parameter which just passes the server domain without the port