### PR TITLE
Regenerate session id only on impossible level

### DIFF
--- a/dvwa/includes/dvwaPage.inc.php
+++ b/dvwa/includes/dvwaPage.inc.php
@@ -42,7 +42,6 @@ if( !isset( $_COOKIE[ 'security' ] ) || !in_array( $_COOKIE[ 'security' ], $secu
  * it will just cause a new Set-Cookie header to be sent with the new right
  * flags and the new id (or the same one if we wish to keep it).
 */
-
 function dvwa_start_session() {
 	// This will setup the session cookie based on
 	// the security level.
@@ -65,7 +64,7 @@ function dvwa_start_session() {
 	 * Need to do this as you can't update the settings of a session
 	 * while it is open. So check if one is open, close it if needed
 	 * then update the values and start it again.
-	 */
+	*/
 	if (session_status() == PHP_SESSION_ACTIVE) {
 		session_write_close();
 	}
@@ -94,7 +93,7 @@ function dvwa_start_session() {
 	 * already exists, we don't want it to change after authentication. We thus
 	 * set the id to its previous value using session_id(), which will force
 	 * the Set-Cookie header.
-	 */
+	*/
 	if ($security_level == 'impossible') {
 		session_start();
 		session_regenerate_id(); // force a new id to be generated

--- a/dvwa/includes/dvwaPage.inc.php
+++ b/dvwa/includes/dvwaPage.inc.php
@@ -39,8 +39,8 @@ if( !isset( $_COOKIE[ 'security' ] ) || !in_array( $_COOKIE[ 'security' ], $secu
  * just setting the flags and doing a session_start() does not change anything.
  * For this, session_id() or session_regenerate_id() can be used.
  * Both keep the existing session values, so nothing is lost,
- * it will just cause a new Set-Cookie header to be sent with the new right flags
- * and the new id (or the same one if we wish to keep it).
+ * it will just cause a new Set-Cookie header to be sent with the new right
+ * flags and the new id (or the same one if we wish to keep it).
 */
 
 function dvwa_start_session() {
@@ -65,7 +65,7 @@ function dvwa_start_session() {
 	 * Need to do this as you can't update the settings of a session
 	 * while it is open. So check if one is open, close it if needed
 	 * then update the values and start it again.
-	*/
+	 */
 	if (session_status() == PHP_SESSION_ACTIVE) {
 		session_write_close();
 	}
@@ -79,16 +79,30 @@ function dvwa_start_session() {
 		'samesite' => $samesite
 	]);
 
-	// We need to force a new Set-Cookie header with the updated flags by updating the session id
-	// because session_start() might not generate a Set-Cookie header if a cookie already exists
+	/*
+	 * We need to force a new Set-Cookie header with the updated flags by updating
+	 * the session id, either regenerating it or setting it to a value, because
+	 * session_start() might not generate a Set-Cookie header if a cookie already
+	 * exists.
+	 *
+	 * For impossible security level, we regenerate the session id, PHP will
+	 * generate a new random id. This is good security practice because it
+	 * prevents the reuse of a previous unauthenticated id that an attacker
+	 * might have knowledge of (aka session fixation attack).
+   *
+	 * For lower levels, we want to allow session fixation attacks, so if an id
+	 * already exists, we don't want it to change after authentication. We thus
+	 * set the id to its previous value using session_id(), which will force
+	 * the Set-Cookie header.
+	 */
 	if ($security_level == 'impossible') {
 		session_start();
-		session_regenerate_id(); // generate a new id, this will prevent session fixation attacks
+		session_regenerate_id(); // force a new id to be generated
 	}
 	else {
-		if (isset($_COOKIE[session_name()])) // if id already exists
-			session_id($_COOKIE[session_name()]); // keep the same id
-		session_start(); // otherwise a new one will be generated
+		if (isset($_COOKIE[session_name()])) // if a session id already exists
+			session_id($_COOKIE[session_name()]); // we keep the same id
+		session_start(); // otherwise a new one will be generated here
 	}
 }
 
@@ -207,7 +221,7 @@ function dvwaSecurityLevelSet( $pSecurityLevel ) {
 	$_COOKIE['security'] = $pSecurityLevel;
 }
 
-function dvwaLocaleGet() {	
+function dvwaLocaleGet() {
 	$dvwaSession =& dvwaSessionGrab();
 	return $dvwaSession[ 'locale' ];
 }
@@ -340,7 +354,7 @@ function dvwaHtmlEcho( $pPage ) {
 	$securityLevelHtml = "<em>Security Level:</em> {$securityLevelHtml}";
 	$localeHtml = '<em>Locale:</em> ' . ( dvwaLocaleGet() );
 	$sqliDbHtml = '<em>SQLi DB:</em> ' . ( dvwaSQLiDBGet() );
-	
+
 
 	$messagesHtml = messagesPopAllToHtml();
 	if( $messagesHtml ) {
@@ -348,7 +362,7 @@ function dvwaHtmlEcho( $pPage ) {
 	}
 
 	$systemInfoHtml = "";
-	if( dvwaIsLoggedIn() ) 
+	if( dvwaIsLoggedIn() )
 		$systemInfoHtml = "<div align=\"left\">{$userInfoHtml}<br />{$securityLevelHtml}<br />{$localeHtml}<br />{$sqliDbHtml}</div>";
 	if( $pPage[ 'source_button' ] ) {
 		$systemInfoHtml = dvwaButtonSourceHtmlGet( $pPage[ 'source_button' ] ) . " $systemInfoHtml";


### PR DESCRIPTION
To force a new Set-Cookie header in order to update the flags, a call to session_regenerate_id() is made.
This prevents session fixation attacks.

This commit only regenerate the id if the level is impossible.
Otherwise, session_id() is called, with the current id if it exists, which will also force a Set-Cookie header, with the correct flags.