### PR TITLE
Configuration via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ along with Damn Vulnerable Web Application (DVWA).  If not, see <https://www.gnu
 ## Internationalisation
 
 This file is available in multiple languages:
+
 - Arabic: [العربية](README.ar.md)
 - Chinese: [简体中文](README.zh.md)
 - French: [Français](README.fr.md)
@@ -58,7 +59,7 @@ If you would like to contribute a translation, please submit a PR. Note though, 
 
 While there are various versions of DVWA around, the only supported version is the latest source from the official GitHub repository. You can either clone it from the repo:
 
-```
+```sh
 git clone https://github.com/digininja/DVWA.git
 ```
 
@@ -87,23 +88,27 @@ An automated configuration script for DVWA on Debian-based machines, including K
 
 This will download an install script written by [@IamCarron](https://github.com/IamCarron) and run it automatically. This would not be included here if we did not trust the author and the script as it was when we reviewed it, but there is always the chance of someone going rogue, and so if you don't feel safe running someone else's code without reviewing it yourself, follow the manual process and you can review it once downloaded.
 
-```bash
+```sh
 sudo bash -c "$(curl --fail --show-error --silent --location https://raw.githubusercontent.com/IamCarron/DVWA-Script/main/Install-DVWA.sh)"
 ```
 
 ##### Manually Running the Script
+
 1. **Download the script:**
-   ```bash
+
+   ```sh
    wget https://raw.githubusercontent.com/IamCarron/DVWA-Script/main/Install-DVWA.sh
    ```
 
 2. **Make the script executable:**
-   ```bash
+
+   ```sh
    chmod +x Install-DVWA.sh
    ```
 
 3. **Run the script as root:**
-   ```bash
+
+   ```sh
    sudo ./Install-DVWA.sh
    ```
 
@@ -204,7 +209,7 @@ If you are using a Debian based Linux distribution, you will need to install the
 
 I would recommend doing an update before this, just so you make sure you are going to get the latest version of everything.
 
-```
+```sh
 apt update
 apt install -y apache2 mariadb-server mariadb-client php php-mysqli php-gd libapache2-mod-php
 ```
@@ -223,11 +228,23 @@ On Windows, this can be a bit harder if you are hiding file extensions, if you a
 
 [How to Make Windows Show File Extensions](https://www.howtogeek.com/205086/beginner-how-to-make-windows-show-file-extensions/)
 
+### Config with environment variables
+
+Instead of modifying the configuration file, you can also set most settings using environment variables. In a Docker or Kubernetes deployment, this allows you to modify the configuration without creating a new Docker image. You'll find the variables in the [config/config.inc.php.dist](config/config.inc.php.dist) file.
+
+If you want to set the default security level to "low", simply add the following line to the [compose.yml](./compose.yml) file:
+
+```yml
+environment:
+  - DB_SERVER=db
+  - DEFAULT_SECURITY_LEVEL=low
+```
+
 ### Database Setup
 
 To set up the database, simply click on the `Setup DVWA` button in the main menu, then click on the `Create / Reset Database` button. This will create / reset the database for you with some data in.
 
-If you receive an error while trying to create your database, make sure your database credentials are correct within `./config/config.inc.php`. *This differs from config.inc.php.dist, which is an example file.*
+If you receive an error while trying to create your database, make sure your database credentials are correct within `./config/config.inc.php`. _This differs from config.inc.php.dist, which is an example file._
 
 The variables are set to the following by default:
 
@@ -273,19 +290,19 @@ In this state, you can access all the features without needing to log in and set
 
 ### Folder Permissions
 
-* `./hackable/uploads/` - Needs to be writeable by the web service (for File Upload).
+- `./hackable/uploads/` - Needs to be writeable by the web service (for File Upload).
 
 ### PHP configuration
 
 On Linux systems, likely found in `/etc/php/x.x/fpm/php.ini` or `/etc/php/x.x/apache2/php.ini`.
 
-* To allow  Remote File Inclusions (RFI):
-    * `allow_url_include = on` [[allow_url_include](https://secure.php.net/manual/en/filesystem.configuration.php#ini.allow-url-include)]
-    * `allow_url_fopen = on` [[allow_url_fopen](https://secure.php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen)]
+- To allow  Remote File Inclusions (RFI):
+  - `allow_url_include = on` [[allow_url_include](https://secure.php.net/manual/en/filesystem.configuration.php#ini.allow-url-include)]
+  - `allow_url_fopen = on` [[allow_url_fopen](https://secure.php.net/manual/en/filesystem.configuration.php#ini.allow-url-fopen)]
 
-* To make sure PHP shows all error messages:
-    * `display_errors = on` [[display_errors](https://secure.php.net/manual/en/errorfunc.configuration.php#ini.display-errors)]
-    * `display_startup_errors = on` [[display_startup_errors](https://secure.php.net/manual/en/errorfunc.configuration.php#ini.display-startup-errors)]
+- To make sure PHP shows all error messages:
+  - `display_errors = on` [[display_errors](https://secure.php.net/manual/en/errorfunc.configuration.php#ini.display-errors)]
+  - `display_startup_errors = on` [[display_startup_errors](https://secure.php.net/manual/en/errorfunc.configuration.php#ini.display-startup-errors)]
 
 Make sure you restart the php service or Apache after making the changes.
 
@@ -297,8 +314,8 @@ Generated a pair of API keys from <https://www.google.com/recaptcha/admin/create
 
 These then go in the following sections of `./config/config.inc.php`:
 
-* `$_DVWA[ 'recaptcha_public_key' ]`
-* `$_DVWA[ 'recaptcha_private_key' ]`
+- `$_DVWA[ 'recaptcha_public_key' ]`
+- `$_DVWA[ 'recaptcha_private_key' ]`
 
 ### Default Credentials
 
@@ -308,7 +325,7 @@ These then go in the following sections of `./config/config.inc.php`:
 
 _...can easily be brute forced ;)_
 
-Login URL: http://127.0.0.1/login.php
+Login URL: <http://127.0.0.1/login.php>
 
 _Note: This will be different if you installed DVWA into a different directory._
 
@@ -333,14 +350,14 @@ Logs can also be accessed from the terminal.
 1. Open a terminal and change its working directory to DVWA
 2. Show the merged logs
 
-    ```shell
+    ```sh
     docker compose logs
     ```
 
    In case you want to export the logs to a file, e.g. `dvwa.log`
 
-   ```shell
-   docker compose logs >dvwa.log
+   ```sh
+   docker compose logs > dvwa.log
    ```
 
 #### I want to run DVWA on a different port
@@ -388,7 +405,7 @@ On Linux systems Apache generates two log files by default, `access.log` and `er
 
 When submitting error reports, problems, anything like that, please include at least the last five lines from each of these files. On Debian based systems you can get these like this:
 
-```
+```sh
 tail -n 5 /var/log/apache2/access.log /var/log/apache2/error.log
 ```
 
@@ -414,7 +431,7 @@ So after setup, if you try to visit the site and get a `404`, think about where 
 
 If you see the following when running the setup script it means the username or password in the config file do not match those configured on the database:
 
-```
+```mariadb
 Database Error #1045: Access denied for user 'notdvwa'@'localhost' (using password: YES).
 ```
 
@@ -422,7 +439,7 @@ The error is telling you that you are using the username `notdvwa`.
 
 The following error says you have pointed the config file at the wrong database.
 
-```
+```mariadb
 SQL: Access denied for user 'dvwa'@'localhost' to database 'notdvwa'
 ```
 
@@ -432,15 +449,15 @@ The first thing to do is to double check what you think you put in the config fi
 
 If it matches what you expect, the next thing to do is to check you can log in as the user on the command line. Assuming you have a database user of `dvwa` and a password of `p@ssw0rd`, run the following command:
 
-```
+```sh
 mysql -u dvwa -pp@ssw0rd -D dvwa
 ```
 
-*Note: There is no space after the -p*
+_Note: There is no space after the -p_
 
 If you see the following, the password is correct:
 
-```
+```mariadb
 Welcome to the MariaDB monitor.  Commands end with ; or \g.
 Your MariaDB connection id is 14
 Server version: 10.3.22-MariaDB-0ubuntu0.19.10.1 Ubuntu 19.10
@@ -456,19 +473,19 @@ As you can connect on the command line, it is likely something wrong in the conf
 
 If you see the following, the username or password you are using is wrong. Repeat the [Database Setup](#database-setup) steps and make sure you use the same username and password throughout the process.
 
-```
+```mariadb
 ERROR 1045 (28000): Access denied for user 'dvwa'@'localhost' (using password: YES)
 ```
 
 If you get the following, the user credentials are correct but the user does not have access to the database. Again, repeat the setup steps and check the database name you are using.
 
-```
+```mariadb
 ERROR 1044 (42000): Access denied for user 'dvwa'@'localhost' to database 'dvwa'
 ```
 
 The final error you could get is this:
 
-```
+```mariadb
 ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (2)
 ```
 
@@ -482,7 +499,7 @@ sudo service mysql start
 
 An error similar to this one:
 
-```
+```mariadb
 Fatal error: Uncaught mysqli_sql_exception: Connection refused in /var/sites/dvwa/non-secure/htdocs/dvwa/includes/dvwaPage.inc.php:535
 ```
 
@@ -490,19 +507,19 @@ Means your database server is not running or you've got the wrong IP address in 
 
 Check this line in the config file to see where the database server is expected to be:
 
-```
+```php
 $_DVWA[ 'db_server' ]   = '127.0.0.1';
 ```
 
 Then go to this server and check that it is running. In Linux this can be done with:
 
-```
+```sh
 systemctl status mariadb.service
 ```
 
 And you are looking for something like this, the important bit is that it says `active (running)`.
 
-```
+```sh
 ● mariadb.service - MariaDB 10.5.19 database server
      Loaded: loaded (/lib/systemd/system/mariadb.service; enabled; preset: enabled)
      Active: active (running) since Thu 2024-03-14 16:04:25 GMT; 1 week 5 days ago
@@ -510,7 +527,7 @@ And you are looking for something like this, the important bit is that it says `
 
 If it is not running, you can start it with:
 
-```
+```sh
 sudo systemctl stop mariadb.service 
 ```
 
@@ -522,7 +539,7 @@ In Windows, check the status in the XAMPP console.
 
 With the most recent versions of MySQL, PHP can no longer talk to the database in its default configuration. If you try to run the setup script and get the following message it means you have configuration.
 
-```
+```mariadb
 Database Error #2054: The server requested authentication method unknown to the client.
 ```
 
@@ -570,7 +587,7 @@ After all that, the setup process should now work as normal.
 
 If you want more information see the following page: <https://www.php.net/manual/en/mysqli.requirements.php>.
 
-### Database Error #2002: No such file or directory.
+### Database Error #2002: No such file or directory
 
 The database server is not running. In a Debian based distro this can be done with:
 
@@ -596,7 +613,7 @@ Apache may not have high enough privileges to run commands on the web server. If
 
 You may be running into problems with SELinux.  Either disable SELinux or run this command to allow the web server to talk to the database:
 
-```
+```sh
 setsebool -P httpd_can_network_connect_db 1
 ```
 
@@ -635,7 +652,7 @@ I am not going to cover how to get SQLite3 working with PHP, but it should be a 
 
 To make the switch, simply edit the config file and add or edit these lines:
 
-```
+```php
 $_DVWA["SQLI_DB"] = "sqlite";
 $_DVWA["SQLITE_DB"] = "sqli.db";
 ```
@@ -675,4 +692,4 @@ The app has vulnerabilities, it is deliberate. Most are the well documented ones
 
 Project Home: <https://github.com/digininja/DVWA>
 
-*Created by the DVWA team*
+_Created by the DVWA team_

--- a/config/config.inc.php.dist
+++ b/config/config.inc.php.dist
@@ -5,7 +5,7 @@
 #   Thanks to @digininja for the fix.
 
 # Database management system to use
-$DBMS = 'MySQL';
+$DBMS = getenv('DBMS') ?: 'MySQL';
 #$DBMS = 'PGSQL'; // Currently disabled
 
 # Database variables
@@ -16,31 +16,31 @@ $DBMS = 'MySQL';
 #   See README.md for more information on this.
 $_DVWA = array();
 $_DVWA[ 'db_server' ]   = getenv('DB_SERVER') ?: '127.0.0.1';
-$_DVWA[ 'db_database' ] = 'dvwa';
-$_DVWA[ 'db_user' ]     = 'dvwa';
-$_DVWA[ 'db_password' ] = 'p@ssw0rd';
-$_DVWA[ 'db_port']      = '3306';
+$_DVWA[ 'db_database' ] = getenv('DB_DATABASE') ?: 'dvwa';
+$_DVWA[ 'db_user' ]     = getenv('DB_USER') ?: 'dvwa';
+$_DVWA[ 'db_password' ] = getenv('DB_PASSWORD') ?: 'p@ssw0rd';
+$_DVWA[ 'db_port']      = getenv('DB_PORT') ?: '3306';
 
 # ReCAPTCHA settings
 #   Used for the 'Insecure CAPTCHA' module
 #   You'll need to generate your own keys at: https://www.google.com/recaptcha/admin
-$_DVWA[ 'recaptcha_public_key' ]  = '';
-$_DVWA[ 'recaptcha_private_key' ] = '';
+$_DVWA[ 'recaptcha_public_key' ]  = getenv('RECAPTCHA_PUBLIC_KEY') ?: '';
+$_DVWA[ 'recaptcha_private_key' ] = getenv('RECAPTCHA_PRIVATE_KEY') ?: '';
 
 # Default security level
 #   Default value for the security level with each session.
 #   The default is 'impossible'. You may wish to set this to either 'low', 'medium', 'high' or impossible'.
-$_DVWA[ 'default_security_level' ] = 'impossible';
+$_DVWA[ 'default_security_level' ] = getenv('DEFAULT_SECURITY_LEVEL') ?: 'impossible';
 
 # Default locale
 #   Default locale for the help page shown with each session.
 #   The default is 'en'. You may wish to set this to either 'en' or 'zh'.
-$_DVWA[ 'default_locale' ] = 'en';
+$_DVWA[ 'default_locale' ] = getenv('DEFAULT_LOCALE') ?: 'en';
 
 # Disable authentication
 #   Some tools don't like working with authentication and passing cookies around
 #   so this setting lets you turn off authentication.
-$_DVWA[ 'disable_authentication' ] = false;
+$_DVWA[ 'disable_authentication' ] = getenv('DISABLE_AUTHENTICATION') ?: false;
 
 define ('MYSQL', 'mysql');
 define ('SQLITE', 'sqlite');
@@ -49,7 +49,7 @@ define ('SQLITE', 'sqlite');
 #   Use this to switch the backend database used in the SQLi and Blind SQLi labs.
 #   This does not affect the backend for any other services, just these two labs.
 #   If you do not understand what this means, do not change it.
-$_DVWA['SQLI_DB'] = MYSQL;
+$_DVWA['SQLI_DB'] = getenv('SQLI_DB') ?: MYSQL;
 #$_DVWA['SQLI_DB'] = SQLITE;
 #$_DVWA['SQLITE_DB'] = 'sqli.db';
 


### PR DESCRIPTION
Full credits to @alles-klar for the original PR #592.

This PR adds the option of configuring DVWA via environment variables. This allows users to change the configuration without rebuilding the Docker image and is particularly useful in a Docker or Kubernetes deployment.

I believe this PR was incorrectly reverted in #605 and was not the cause of #604. The only issue in the original PR came from a mismatch between the environment variable name in config/config.inc.php.dist and in the README.md. The database server variable was changed from DB_SERVER to DVWA_DB_SERVER, which caused some confusion. I've kept the original name of the variable in this PR to avoid any breaking change.