### PR TITLE
exec-high: reorder subtitutions to correctly replace double pipe

### DIFF
--- a/vulnerabilities/exec/source/high.php
+++ b/vulnerabilities/exec/source/high.php
@@ -6,6 +6,7 @@ if( isset( $_POST[ 'Submit' ]  ) ) {
 
 	// Set blacklist
 	$substitutions = array(
+		'||' => '',
 		'&'  => '',
 		';'  => '',
 		'| ' => '',
@@ -14,7 +15,6 @@ if( isset( $_POST[ 'Submit' ]  ) ) {
 		'('  => '',
 		')'  => '',
 		'`'  => '',
-		'||' => '',
 	);
 
 	// Remove any of the characters in the array (blacklist).


### PR DESCRIPTION
Hi 👋🏻,

While doing the “Command Injection” challenge with the level set to high, a friend (@tymmi78) stumbled upon a bug.

It's possible to validate the challenge by entering the following:
<details>
<summary>Spoiler</summary>

<code>foo || whoami</code>

This happens because <code>| </code> is removed before <code>||</code> is replaced. It then becomes a simple shell pipe.

This is what I thought to be the intended solution

<code>foo |whoami</code>
</details>

It seems to me that this is not the exact behavior that would be expected. The simpler `or` operator should be correctly replaced, and “attackers” would actually need to spot the whitespace after the pipe operator in the substitution list.