### PR TITLE
Serve files locally to make development easier on Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,17 @@ Running `docker compose up -d` should trigger Docker to build an image from loca
 See also: [`pull_policy`](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#pull_policy
 ).
 
+#### Serve local files
+
+If your making local changes and don't want to build the project for every change :
+1. go to `compose.yml` and uncomment :
+    `
+        # volumes:
+        #   - ./:/var/www/html
+    `
+2. Run `cp config/config.inc.php.dist config/config.inc.php` to copy the default config file.
+3. Run `docker compose up -d` and every changes in local files will reflect on the container.
+
 ### PHP Versions
 
 Ideally you should be using the latest stable version of PHP as that is the version that this app will be developed and tested on.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ If your making local changes and don't want to build the project for every chang
         #   - ./:/var/www/html
     `
 2. Run `cp config/config.inc.php.dist config/config.inc.php` to copy the default config file.
-3. Run `docker compose up -d` and every changes in local files will reflect on the container.
+3. Run `docker compose up -d` and changes to local files will reflect on the container.
 
 ### PHP Versions
 

--- a/compose.yml
+++ b/compose.yml
@@ -16,6 +16,9 @@ services:
       - DB_SERVER=db
     depends_on:
       - db
+    # Uncomment the next 2 lines to serve local source
+    # volumes:
+    #   - ./:/var/www/html
     networks:
       - dvwa
     ports:


### PR DESCRIPTION
Simple changes to make development easier on Docker :
- Adjust compose.yml to allow serving local files by uncommenting 2 lines
- Adjust README.md to document the process