### PR TITLE
fix(weak-id): replace predictable mt_rand with cryptographically secure random_bytes

### DIFF
--- a/vulnerabilities/weak_id/source/impossible.php
+++ b/vulnerabilities/weak_id/source/impossible.php
@@ -3,7 +3,7 @@
 $html = "";
 
 if ($_SERVER['REQUEST_METHOD'] == "POST") {
-	$cookie_value = sha1(mt_rand() . time() . "Impossible");
+	$cookie_value = bin2hex(random_bytes(20));
 	setcookie("dvwaSession", $cookie_value, time()+3600, "/vulnerabilities/weak_id/", $_SERVER['HTTP_HOST'], true, true);
 }
 ?>


### PR DESCRIPTION
## summary

`mt_rand()` is seeded with a predictable value and not suitable for security-sensitive contexts. `random_bytes()` uses the OS CSPRNG instead, which is cryptographically unpredictable

## what changed

`sha1(mt_rand() . time() . "Impossible")`: replaced with `bin2hex(random_bytes(20))` to generate a 40-character cryptographically secure hex string

