### PR TITLE
fix(crypto): md5 is for the weak

### DIFF
--- a/dvwa/includes/DBMS/MySQL.php
+++ b/dvwa/includes/DBMS/MySQL.php
@@ -39,7 +39,7 @@ if( !@((bool)mysqli_query($GLOBALS["___mysqli_ston"], "USE " . $_DVWA[ 'db_datab
 	dvwaPageReload();
 }
 
-$create_tb = "CREATE TABLE users (user_id int(6),first_name varchar(15),last_name varchar(15), user varchar(15), password varchar(32),avatar varchar(70), last_login TIMESTAMP, failed_login INT(3), PRIMARY KEY (user_id));";
+$create_tb = "CREATE TABLE users (user_id int(6),first_name varchar(15),last_name varchar(15), user varchar(15), password varchar(255),avatar varchar(70), last_login TIMESTAMP, failed_login INT(3), PRIMARY KEY (user_id));";
 if( !mysqli_query($GLOBALS["___mysqli_ston"],  $create_tb ) ) {
 	dvwaMessagePush( "Table could not be created<br />SQL: " . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) );
 	dvwaPageReload();
@@ -52,11 +52,11 @@ $base_dir= str_replace ("setup.php", "", $_SERVER['SCRIPT_NAME']);
 $avatarUrl  = $base_dir . 'hackable/users/';
 
 $insert = "INSERT INTO users VALUES
-	('1','admin','admin','admin',MD5('password'),'{$avatarUrl}admin.jpg', NOW(), '0'),
-	('2','Gordon','Brown','gordonb',MD5('abc123'),'{$avatarUrl}gordonb.jpg', NOW(), '0'),
-	('3','Hack','Me','1337',MD5('charley'),'{$avatarUrl}1337.jpg', NOW(), '0'),
-	('4','Pablo','Picasso','pablo',MD5('letmein'),'{$avatarUrl}pablo.jpg', NOW(), '0'),
-	('5','Bob','Smith','smithy',MD5('password'),'{$avatarUrl}smithy.jpg', NOW(), '0');";
+	('1','admin','admin','admin','\$2y\$12\$rf2N1mIKbZu9NZWRzY7FfOYtqLGCNB8aw78xkGGHQyP5ZY2LJIs6u','{$avatarUrl}admin.jpg', NOW(), '0'),
+	('2','Gordon','Brown','gordonb','\$2y\$12\$JVFYv1SekB3U8vyzNfAxU.PXXF1vEFhR6v.9vDSe9q2eoTMEyrpGC','{$avatarUrl}gordonb.jpg', NOW(), '0'),
+	('3','Hack','Me','1337','\$2y\$12\$CiOXblIO7H8Vd2eRRQAmIO6VDxVuqSGiTxs6zJ75juL.rQWNAqxby','{$avatarUrl}1337.jpg', NOW(), '0'),
+	('4','Pablo','Picasso','pablo','\$2y\$12\$S9O/dhbLvIDuMOIMXj2M4uf/Cjd3rzUvhfoHIqhEVuR7YpX6fvGk2','{$avatarUrl}pablo.jpg', NOW(), '0'),
+	('5','Bob','Smith','smithy','\$2y\$12\$E.1K4MDsXvuei096MM.oHOQtYMEmGJmAvIoRaFOjm6K3t6U24HXLe','{$avatarUrl}smithy.jpg', NOW(), '0');";
 if( !mysqli_query($GLOBALS["___mysqli_ston"],  $insert ) ) {
 	dvwaMessagePush( "Data could not be inserted into 'users' table<br />SQL: " . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) );
 	dvwaPageReload();

--- a/dvwa/includes/DBMS/PGSQL.php
+++ b/dvwa/includes/DBMS/PGSQL.php
@@ -58,11 +58,11 @@ $stripPos = strpos( $baseUrl, 'dvwa/setup.php' );
 $baseUrl = substr( $baseUrl, 0, $stripPos ).'dvwa/hackable/users/';
 
 $insert = "INSERT INTO users VALUES
-	('1','admin','admin','admin',MD5('password'),'{$baseUrl}admin.jpg'),
-	('2','Gordon','Brown','gordonb',MD5('abc123'),'{$baseUrl}gordonb.jpg'),
-	('3','Hack','Me','1337',MD5('charley'),'{$baseUrl}1337.jpg'),
-	('4','Pablo','Picasso','pablo',MD5('letmein'),'{$baseUrl}pablo.jpg'),
-	('5','bob','smith','smithy',MD5('password'),'{$baseUrl}smithy.jpg');";
+	('1','admin','admin','admin','\$2y\$12\$rf2N1mIKbZu9NZWRzY7FfOYtqLGCNB8aw78xkGGHQyP5ZY2LJIs6u','{$baseUrl}admin.jpg'),
+	('2','Gordon','Brown','gordonb','\$2y\$12\$JVFYv1SekB3U8vyzNfAxU.PXXF1vEFhR6v.9vDSe9q2eoTMEyrpGC','{$baseUrl}gordonb.jpg'),
+	('3','Hack','Me','1337','\$2y\$12\$CiOXblIO7H8Vd2eRRQAmIO6VDxVuqSGiTxs6zJ75juL.rQWNAqxby','{$baseUrl}1337.jpg'),
+	('4','Pablo','Picasso','pablo','\$2y\$12\$S9O/dhbLvIDuMOIMXj2M4uf/Cjd3rzUvhfoHIqhEVuR7YpX6fvGk2','{$baseUrl}pablo.jpg'),
+	('5','Bob','Smith','smithy','\$2y\$12\$E.1K4MDsXvuei096MM.oHOQtYMEmGJmAvIoRaFOjm6K3t6U24HXLe','{$baseUrl}smithy.jpg');";
 if( !pg_query( $insert ) ) {
 	dvwaMessagePush( "Data could not be inserted into 'users' table<br />SQL: " . pg_last_error() );
 	dvwaPageReload();

--- a/login.php
+++ b/login.php
@@ -24,7 +24,6 @@ if( isset( $_POST[ 'Login' ] ) ) {
 	$pass = $_POST[ 'password' ];
 	$pass = stripslashes( $pass );
 	$pass = ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"],  $pass ) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
-	$pass = md5( $pass );
 
 	$query = ("SELECT table_schema, table_name, create_time
 				FROM information_schema.tables
@@ -35,13 +34,18 @@ if( isset( $_POST[ 'Login' ] ) ) {
 		dvwaMessagePush( "First time using DVWA.<br />Need to run 'setup.php'." );
 		dvwaRedirect( DVWA_WEB_PAGE_TO_ROOT . 'setup.php' );
 	}
-
-	$query  = "SELECT * FROM `users` WHERE user='$user' AND password='$pass';";
+    
+	$query  = "SELECT * FROM `users` WHERE user='{$user}';";
 	$result = @mysqli_query($GLOBALS["___mysqli_ston"],  $query ) or die( '<pre>' . ((is_object($GLOBALS["___mysqli_ston"])) ? mysqli_error($GLOBALS["___mysqli_ston"]) : (($___mysqli_res = mysqli_connect_error()) ? $___mysqli_res : false)) . '.<br />Try <a href="setup.php">installing again</a>.</pre>' );
-	if( $result && mysqli_num_rows( $result ) == 1 ) {    // Login Successful...
-		dvwaMessagePush( "You have logged in as '{$user}'" );
-		dvwaLogin( $user );
-		dvwaRedirect( DVWA_WEB_PAGE_TO_ROOT . 'index.php' );
+
+	if( $result && mysqli_num_rows( $result ) == 1 ) {
+		$row = mysqli_fetch_assoc( $result );
+
+		if( password_verify( $pass, $row['password'] ) ) {
+			dvwaMessagePush( "You have logged in as '{$user}'" );
+			dvwaLogin( $user );
+			dvwaRedirect( DVWA_WEB_PAGE_TO_ROOT . 'index.php' );
+		}
 	}
 
 	// Login failed

--- a/vulnerabilities/brute/source/impossible.php
+++ b/vulnerabilities/brute/source/impossible.php
@@ -13,7 +13,6 @@ if( isset( $_POST[ 'Login' ] ) && isset ($_POST['username']) && isset ($_POST['p
 	$pass = $_POST[ 'password' ];
 	$pass = stripslashes( $pass );
 	$pass = ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"],  $pass ) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
-	$pass = md5( $pass );
 
 	// Default values
 	$total_failed_login = 3;
@@ -50,14 +49,13 @@ if( isset( $_POST[ 'Login' ] ) && isset ($_POST['username']) && isset ($_POST['p
 	}
 
 	// Check the database (if username matches the password)
-	$data = $db->prepare( 'SELECT * FROM users WHERE user = (:user) AND password = (:password) LIMIT 1;' );
+	$data = $db->prepare( 'SELECT * FROM users WHERE user = (:user) LIMIT 1;' );
 	$data->bindParam( ':user', $user, PDO::PARAM_STR);
-	$data->bindParam( ':password', $pass, PDO::PARAM_STR );
 	$data->execute();
 	$row = $data->fetch();
 
 	// If its a valid login...
-	if( ( $data->rowCount() == 1 ) && ( $account_locked == false ) ) {
+	if( $row && password_verify( $pass, $row['password'] ) && ( $account_locked == false ) ) {
 		// Get users details
 		$avatar       = $row[ 'avatar' ];
 		$failed_login = $row[ 'failed_login' ];

--- a/vulnerabilities/captcha/source/impossible.php
+++ b/vulnerabilities/captcha/source/impossible.php
@@ -10,18 +10,13 @@ if( isset( $_POST[ 'Change' ] ) ) {
 	// Get input
 	$pass_new  = $_POST[ 'password_new' ];
 	$pass_new  = stripslashes( $pass_new );
-	$pass_new  = ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"],  $pass_new ) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
-	$pass_new  = md5( $pass_new );
 
 	$pass_conf = $_POST[ 'password_conf' ];
 	$pass_conf = stripslashes( $pass_conf );
-	$pass_conf = ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"],  $pass_conf ) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
-	$pass_conf = md5( $pass_conf );
+
 
 	$pass_curr = $_POST[ 'password_current' ];
 	$pass_curr = stripslashes( $pass_curr );
-	$pass_curr = ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"],  $pass_curr ) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
-	$pass_curr = md5( $pass_curr );
 
 	// Check CAPTCHA from 3rd party
 	$resp = recaptcha_check_answer(
@@ -36,29 +31,32 @@ if( isset( $_POST[ 'Change' ] ) ) {
 		$hide_form = false;
 	}
 	else {
-		// Check that the current password is correct
-		$data = $db->prepare( 'SELECT password FROM users WHERE user = (:user) AND password = (:password) LIMIT 1;' );
-		$data->bindParam( ':user', dvwaCurrentUser(), PDO::PARAM_STR );
-		$data->bindParam( ':password', $pass_curr, PDO::PARAM_STR );
-		$data->execute();
+        // Check that the current password is correct
+        $data = $db->prepare( 'SELECT password FROM users WHERE user = (:user) LIMIT 1;' );
+        $data->bindParam( ':user', dvwaCurrentUser(), PDO::PARAM_STR );
+        $data->execute();
+        $row = $data->fetch();
 
-		// Do both new password match and was the current password correct?
-		if( ( $pass_new == $pass_conf) && ( $data->rowCount() == 1 ) ) {
+        // Do both new password match and was the current password correct?
+        if( ( $pass_new == $pass_conf ) && $row && password_verify( $pass_curr, $row['password'] ) ) {
+			// Hash the new password
+			$pass_new  = password_hash( $pass_new, PASSWORD_BCRYPT );
+
 			// Update the database
-			$data = $db->prepare( 'UPDATE users SET password = (:password) WHERE user = (:user);' );
-			$data->bindParam( ':password', $pass_new, PDO::PARAM_STR );
-			$data->bindParam( ':user', dvwaCurrentUser(), PDO::PARAM_STR );
-			$data->execute();
+            $data = $db->prepare( 'UPDATE users SET password = (:password) WHERE user = (:user);' );
+            $data->bindParam( ':password', $pass_new, PDO::PARAM_STR );
+            $data->bindParam( ':user', dvwaCurrentUser(), PDO::PARAM_STR );
+            $data->execute();
 
-			// Feedback for the end user - success!
-			$html .= "<pre>Password Changed.</pre>";
-		}
-		else {
-			// Feedback for the end user - failed!
-			$html .= "<pre>Either your current password is incorrect or the new passwords did not match.<br />Please try again.</pre>";
-			$hide_form = false;
-		}
-	}
+            // Feedback for the end user - success!
+            $html .= "<pre>Password Changed.</pre>";
+        }
+        else {
+            // Feedback for the end user - failed!
+            $html .= "<pre>Either your current password is incorrect or the new passwords did not match.<br />Please try again.</pre>";
+            $hide_form = false;
+        }
+    }
 }
 
 // Generate Anti-CSRF token

--- a/vulnerabilities/csrf/source/impossible.php
+++ b/vulnerabilities/csrf/source/impossible.php
@@ -11,22 +11,19 @@ if( isset( $_GET[ 'Change' ] ) ) {
 
 	// Sanitise current password input
 	$pass_curr = stripslashes( $pass_curr );
-	$pass_curr = ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"],  $pass_curr ) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
-	$pass_curr = md5( $pass_curr );
 
 	// Check that the current password is correct
-	$data = $db->prepare( 'SELECT password FROM users WHERE user = (:user) AND password = (:password) LIMIT 1;' );
+	$data = $db->prepare( 'SELECT password FROM users WHERE user = (:user) LIMIT 1;' );
 	$current_user = dvwaCurrentUser();
 	$data->bindParam( ':user', $current_user, PDO::PARAM_STR );
-	$data->bindParam( ':password', $pass_curr, PDO::PARAM_STR );
 	$data->execute();
+	$row = $data->fetch();
 
 	// Do both new passwords match and does the current password match the user?
-	if( ( $pass_new == $pass_conf ) && ( $data->rowCount() == 1 ) ) {
+	if( ( $pass_new == $pass_conf ) && $row && password_verify( $pass_curr, $row['password'] ) ) {
 		// It does!
 		$pass_new = stripslashes( $pass_new );
-		$pass_new = ((isset($GLOBALS["___mysqli_ston"]) && is_object($GLOBALS["___mysqli_ston"])) ? mysqli_real_escape_string($GLOBALS["___mysqli_ston"],  $pass_new ) : ((trigger_error("[MySQLConverterToo] Fix the mysql_escape_string() call! This code does not work.", E_USER_ERROR)) ? "" : ""));
-		$pass_new = md5( $pass_new );
+		$pass_new = password_hash( $pass_new, PASSWORD_BCRYPT );
 
 		// Update database with new password
 		$data = $db->prepare( 'UPDATE users SET password = (:password) WHERE user = (:user);' );
@@ -43,7 +40,6 @@ if( isset( $_GET[ 'Change' ] ) ) {
 		$html .= "<pre>Passwords did not match or current password incorrect.</pre>";
 	}
 }
-
 // Generate Anti-CSRF token
 generateSessionToken();
 


### PR DESCRIPTION
## summary

the core database was using md5 to hash, which is  why?? i changed it to use password_hash() and password_verify() in login.php, MySQL/PGSQL.php, brute/impossible, captcha/impossible, and csrf/impossible.

## what changed

`md5()`: replaced with `password_hash()` for the password shit, why would you use md5 for that
`varchar(32)`: md5 hash size LOL, increased to 255